### PR TITLE
Exclude TSX test files from TypeScript build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "isolatedModules": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
This small integration fix prevents UI test files from being included in production TypeScript builds.

What changed:
- added `**/*.test.tsx` to `tsconfig.json` `exclude`

Why:
- the integration gate failed at `pnpm build` because `.test.tsx` files imported `@jest/globals` and were being type-checked during build
- test files should be validated by `pnpm test`, not compiled as app code
