### PR TITLE
Refresh search and vim navigation on current main

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,21 +87,27 @@ program
     }
   });
 
-// Handle interactive mode if no args provided
-if (process.argv.length === 2) {
-    // Set terminal title
-    process.stdout.write('\x1b]0;Coherence Chat Exporter\x07');
-    // Enter alternate screen buffer
-    process.stdout.write('\x1b[?1049h');
+// Handle interactive mode (default)
+// We use a custom action on the main program to catch cases where no sub-command is used
+program
+    .argument('[path]', 'Path to export file or directory to load in interactive mode')
+    .action(async (path) => {
+        // Set terminal title
+        process.stdout.write('\x1b]0;Coherence Chat Exporter\x07');
+        // Enter alternate screen buffer
+        process.stdout.write('\x1b[?1049h');
 
-    const app = render(React.createElement(App, {
-        onExit: () => app.unmount()
-    }));
+        // If the user runs `coherence`, path is undefined.
+        // If the user runs `coherence myfile.zip`, path is "myfile.zip".
+        const app = render(React.createElement(App, {
+            initialPath: path,
+            onExit: () => app.unmount()
+        }));
 
-    await app.waitUntilExit();
+        await app.waitUntilExit();
 
-    // Exit alternate screen buffer
-    process.stdout.write('\x1b[?1049l');
-} else {
-    program.parse(process.argv);
-}
+        // Exit alternate screen buffer on clean exit
+        process.stdout.write('\x1b[?1049l');
+    });
+
+program.parse(process.argv);

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -12,7 +12,7 @@ export function registerCompletionCommand(program: Command) {
     });
 }
 
-function generateCompletionScript(shell: string, program: Command): string {
+function generateCompletionScript(shell: string, _program: Command): string {
     // Basic completion script generation.
     // In a production environment with `commander`, we might use `omelette` or `tabtab`
     // but `commander` has no built-in "output completion script" feature out of the box for all shells

--- a/src/config-manager.ts
+++ b/src/config-manager.ts
@@ -21,7 +21,7 @@ export class ConfigManager {
     if (!fs.existsSync(configDir)) {
       try {
         fs.mkdirSync(configDir, { recursive: true });
-      } catch (e) {
+      } catch {
         // Fallback to local directory if permission denied (e.g. in sandbox)
         return path.join(process.cwd(), '.chat-archive-config.json');
       }

--- a/src/export/organizer.ts
+++ b/src/export/organizer.ts
@@ -17,7 +17,7 @@ export class Organizer {
     const folder = path.join(year, `${month}-${monthName}`);
 
     // Filename: {day}-{slug}.md
-    // @ts-ignore: slugify types mismatch with ESM in this setup, but runtime is fine
+    // @ts-expect-error: slugify types mismatch with ESM in this setup, but runtime is fine
     const slug = slugify(conversation.title, { lower: true, strict: true }).slice(0, 50);
     const filename = `${day}-${slug}.md`;
 

--- a/src/export/transformer.ts
+++ b/src/export/transformer.ts
@@ -1,6 +1,5 @@
 import matter from 'gray-matter';
 import { Conversation, Message } from '../providers/types.js';
-import { defaultConfig } from '../config.js';
 
 export class MarkdownTransformer {
   toMarkdown(conversation: Conversation): string {

--- a/src/providers/samples.test.ts
+++ b/src/providers/samples.test.ts
@@ -5,7 +5,6 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 const samplesDir = path.resolve(__dirname, '../../samples');
 
 describe('Sample Verification', () => {

--- a/src/tagging/setup.ts
+++ b/src/tagging/setup.ts
@@ -1,8 +1,4 @@
 // Placeholder for explicit download setup if we want to separate it from inference
-import { env } from '@huggingface/transformers';
-import * as path from 'path';
-import * as fs from 'fs';
-import * as os from 'os';
 
 export async function setupModelCache() {
     // Configure cache directory

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -51,9 +51,10 @@ enum MenuOption {
 
 interface AppProps {
   onExit?: () => void;
+  initialPath?: string;
 }
 
-export const App: React.FC<AppProps> = ({ onExit }) => {
+export const App: React.FC<AppProps> = ({ onExit, initialPath }) => {
   const [view, setView] = useState<AppView>(AppView.Menu);
   const [mode, setMode] = useState<AppMode>(AppMode.Export); // Track if we are in direct export or browse mode
   const [providerName, setProviderName] = useState<'claude' | 'chatgpt' | null>(null);
@@ -68,6 +69,61 @@ export const App: React.FC<AppProps> = ({ onExit }) => {
   useEffect(() => {
       configManager.loadConfig();
   }, []);
+
+  // Handle initial path from CLI
+  useEffect(() => {
+    if (initialPath) {
+      setMode(AppMode.Browse);
+      setView(AppView.Loading);
+      setStatus(`Loading from ${initialPath}...`);
+      autoDetectAndLoad(initialPath);
+    }
+  }, [initialPath]);
+
+  const autoDetectAndLoad = async (pathStr: string) => {
+     try {
+       const resolver = new InputResolver();
+       setStatus('Resolving input...');
+       const rawData = await resolver.resolve(pathStr);
+
+       // Try Claude first
+       try {
+         setStatus('Attempting to parse as Claude...');
+         const claudeProvider = new ClaudeProvider();
+         const convs = await claudeProvider.normalize(rawData);
+         if (convs.length > 0) {
+           setProviderName('claude');
+           setLoadedConversations(convs);
+           setView(AppView.Browser);
+           return;
+         }
+       } catch (e) {
+         // Ignore and try next
+       }
+
+       // Try ChatGPT
+       try {
+         setStatus('Attempting to parse as ChatGPT...');
+         const chatgptProvider = new ChatGPTProvider();
+         const convs = await chatgptProvider.normalize(rawData);
+         if (convs.length > 0) {
+           setProviderName('chatgpt');
+           setLoadedConversations(convs);
+           setView(AppView.Browser);
+           return;
+         }
+       } catch (e) {
+         // Ignore
+       }
+
+       throw new Error('Could not auto-detect provider or no conversations found.');
+
+     } catch (e: any) {
+       setStatus(`Error: ${e.message}`);
+       // Give user a moment to see error then go to menu
+       setTimeout(() => setView(AppView.Menu), 2000);
+     }
+  };
 
   const handleMenuSelect = (value: string) => {
     if (value === MenuOption.Exit) {
@@ -109,7 +165,7 @@ export const App: React.FC<AppProps> = ({ onExit }) => {
     }
     if (value === MenuOption.Stats) {
         setMode(AppMode.Stats);
-        if (sessionPath && loadedConversations.length > 0) {
+        if (loadedConversations.length > 0) {
             setView(AppView.Stats);
         } else {
             setView(AppView.SelectProvider);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -42,6 +42,7 @@ enum AppMode {
 enum MenuOption {
   Source = 'source',
   Browse = 'browse',
+  Search = 'search',
   Stats = 'stats',
   Tagging = 'tagging',
   Settings = 'settings',
@@ -74,6 +75,13 @@ export const App: React.FC<AppProps> = ({ onExit }) => {
         else process.exit(0);
         return;
     }
+
+    // If Browse or Search is selected but no data is loaded, redirect to Source selection
+    if ((value === MenuOption.Browse || value === MenuOption.Search) && loadedConversations.length === 0) {
+        setMode(AppMode.Browse); // Intend to browse after loading
+        setView(AppView.SelectProvider);
+        return;
+    }
     if (value === MenuOption.Source) {
         setMode(AppMode.Export);
         // If we have a session path, allow user to confirm or change
@@ -94,6 +102,10 @@ export const App: React.FC<AppProps> = ({ onExit }) => {
         } else {
             setView(AppView.SelectProvider);
         }
+    }
+    if (value === MenuOption.Search) {
+        setMode(AppMode.Browse);
+        setView(AppView.Browser);
     }
     if (value === MenuOption.Stats) {
         setMode(AppMode.Stats);
@@ -216,7 +228,12 @@ export const App: React.FC<AppProps> = ({ onExit }) => {
 
   return (
     <FullScreenLayout>
-      {view === AppView.Menu && <MainMenu onSelect={handleMenuSelect} />}
+      {view === AppView.Menu && (
+        <MainMenu
+           onSelect={handleMenuSelect}
+           hasData={loadedConversations.length > 0}
+        />
+      )}
       {view === AppView.SelectProvider && (
           <ProviderSelect onSelect={handleProviderSelect} onBack={() => setView(AppView.Menu)} />
       )}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -97,7 +97,7 @@ export const App: React.FC<AppProps> = ({ onExit, initialPath }) => {
            setView(AppView.Browser);
            return;
          }
-       } catch (e) {
+       } catch {
          // Ignore and try next
        }
 
@@ -112,7 +112,7 @@ export const App: React.FC<AppProps> = ({ onExit, initialPath }) => {
            setView(AppView.Browser);
            return;
          }
-       } catch (e) {
+       } catch {
          // Ignore
        }
 

--- a/src/ui/components/MainMenu.tsx
+++ b/src/ui/components/MainMenu.tsx
@@ -6,6 +6,13 @@ import gradient from 'gradient-string';
 
 interface Props {
   onSelect: (value: string) => void;
+  hasData?: boolean;
+}
+
+// ItemProps must match ink-select-input's definition which does NOT include 'value'
+interface ItemProps {
+    isSelected?: boolean;
+    label: string;
 }
 
 // A more dramatic ASCII brain (side view with convolutions)
@@ -24,7 +31,7 @@ const BRAIN_ASCII = `
 // Pinkish color from Noto Color Emoji brain
 const BRAIN_PINK = "#F48FB1";
 
-export const MainMenu: React.FC<Props> = ({ onSelect }) => {
+export const MainMenu: React.FC<Props> = ({ onSelect, hasData = false }) => {
   const { stdout } = useStdout();
   const width = stdout?.columns || 80;
 
@@ -39,8 +46,9 @@ export const MainMenu: React.FC<Props> = ({ onSelect }) => {
   }, []);
 
   const items = [
-    { label: '📦 Select Export Source', value: 'source' },
+    { label: hasData ? '📦 Load New Source' : '📦 Load Export Data (Start Here)', value: 'source' },
     { label: '📂 Browse & Export', value: 'browse' },
+    { label: '🔍 Search', value: 'search' },
     { label: '📊 Stats Dashboard', value: 'stats' },
     { label: '🏷️  Configure Tagging', value: 'tagging' },
     { label: '⚙️  Settings', value: 'settings' },
@@ -55,16 +63,43 @@ export const MainMenu: React.FC<Props> = ({ onSelect }) => {
 
   return (
     <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">Chat Archive Tool</Text>
       {/* Top Logo */}
       <Box marginBottom={1}>
         <Text>{logo}</Text>
+      {!hasData && (
+          <Box marginTop={1} borderStyle="single" borderColor="yellow">
+              <Text color="yellow">No data loaded. Please load an export file to begin.</Text>
+          </Box>
+      )}
       </Box>
 
       {/* Content Area */}
       <Box flexDirection="row">
         {/* Left Column: Menu */}
         <Box flexDirection="column" marginRight={4}>
-          <SelectInput items={items} onSelect={(item) => onSelect(item.value)} />
+          <SelectInput
+            items={items}
+            onSelect={(item) => onSelect(item.value)}
+            itemComponent={(props: ItemProps) => {
+                // Determine disabled state based on label content since 'value' is not passed to itemComponent
+                const label = props.label;
+                const requiresData =
+                    label.includes('Browse') ||
+                    label.includes('Search') ||
+                    label.includes('Stats');
+
+                const isDisabled = requiresData && !hasData;
+
+                return (
+                    <Text color={props.isSelected ? 'cyan' : (isDisabled ? 'gray' : 'white')}>
+                        {props.isSelected ? '> ' : '  '}
+                        {props.label}
+                        {isDisabled ? ' (Requires Data)' : ''}
+                    </Text>
+                );
+            }}
+        />
         </Box>
 
         {/* Right Column: Brain */}

--- a/src/ui/components/Settings.tsx
+++ b/src/ui/components/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Box, Text } from 'ink';
 import SelectInput from 'ink-select-input';
 import { configManager } from '../../config-manager.js';

--- a/src/ui/components/__tests__/FileBrowser.test.tsx
+++ b/src/ui/components/__tests__/FileBrowser.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
-import { FileBrowser } from '../FileBrowser.js';
 import { jest } from '@jest/globals';
 
 // We need to use unstable_mockModule for ESM mocking of 'fs'
@@ -37,7 +36,7 @@ describe('FileBrowser', () => {
             { name: 'file1.json', isDirectory: () => false }
         ]);
 
-        const { lastFrame, rerender } = render(
+        const { lastFrame } = render(
             <FileBrowserComponent
                 prompt="Select File"
                 onSubmit={() => {}}

--- a/src/ui/components/__tests__/MainMenu.test.tsx
+++ b/src/ui/components/__tests__/MainMenu.test.tsx
@@ -21,7 +21,7 @@ describe('MainMenu', () => {
     // Check for a distinctive part of the ASCII art derived from "Coherence"
     expect(output).toContain('/ ___|___ | |__');
 
-    expect(output).toContain('Select Export Source');
+    expect(output).toContain('Load Export Data (Start Here)');
     expect(output).toContain('Exit');
   });
 

--- a/src/ui/components/__tests__/MainMenu.test.tsx
+++ b/src/ui/components/__tests__/MainMenu.test.tsx
@@ -36,4 +36,13 @@ describe('MainMenu', () => {
      // "      _---~~(~~-._"
      expect(output).toContain("_---~~(~~-._");
   });
+
+  test('shows data-ready menu state when data is loaded', () => {
+    const { lastFrame } = render(<MainMenu onSelect={() => {}} hasData />);
+    const output = lastFrame();
+
+    expect(output).toContain('Load New Source');
+    expect(output).toContain('Search');
+    expect(output).not.toContain('No data loaded');
+  });
 });

--- a/src/ui/components/browser/Browser.test.tsx
+++ b/src/ui/components/browser/Browser.test.tsx
@@ -92,4 +92,21 @@ describe('Browser Component', () => {
       expect(frame).toContain('Project Alpha Chat');
       expect(frame).not.toContain('Project Beta Chat');
   });
+
+  test('opens deep search from project list with slash key', async () => {
+      const { lastFrame, stdin } = render(
+        <Browser
+            conversations={mockConversations}
+            onExport={() => {}}
+            onBack={() => {}}
+        />
+      );
+
+      stdin.write('/');
+      await delay(100);
+
+      const frame = lastFrame();
+      expect(frame).toContain('Deep Content Search');
+      expect(frame).toContain('Type to search...');
+  });
 });

--- a/src/ui/components/browser/Browser.tsx
+++ b/src/ui/components/browser/Browser.tsx
@@ -3,9 +3,15 @@ import { Box } from 'ink';
 import { ProjectList } from './ProjectList.js';
 import { ConversationList } from './ConversationList.js';
 import { ConversationPreview } from './ConversationPreview.js';
+import { SearchResults } from './SearchResults.js';
 import { Conversation } from '../../../providers/types.js';
 
-type BrowserView = 'projects' | 'conversations' | 'preview';
+enum BrowserView {
+  Projects = 'projects',
+  Conversations = 'conversations',
+  Preview = 'preview',
+  Search = 'search'
+}
 
 interface BrowserProps {
   conversations: Conversation[];
@@ -16,7 +22,8 @@ interface BrowserProps {
 }
 
 export const Browser: React.FC<BrowserProps> = ({ conversations, onExport, onBack, onViewStats, onChangeSource }) => {
-  const [view, setView] = useState<BrowserView>('projects');
+  const [view, setView] = useState<BrowserView>(BrowserView.Projects);
+  const [lastView, setLastView] = useState<BrowserView>(BrowserView.Projects); // Track where we came from
   const [selectedProject, setSelectedProject] = useState<string | null>(null);
   const [selectedUuids, setSelectedUuids] = useState<string[]>([]);
   const [previewConversation, setPreviewConversation] = useState<Conversation | null>(null);
@@ -30,20 +37,21 @@ export const Browser: React.FC<BrowserProps> = ({ conversations, onExport, onBac
 
   return (
     <Box>
-      {view === 'projects' && (
+      {view === BrowserView.Projects && (
         <ProjectList
             conversations={conversations}
             onSelectProject={(project: string | null) => {
                 setSelectedProject(project);
-                setView('conversations');
+                setView(BrowserView.Conversations);
             }}
+            onSearch={() => setView(BrowserView.Search)}
             onBack={onBack}
             onViewStats={onViewStats}
             onChangeSource={onChangeSource}
         />
       )}
 
-      {view === 'conversations' && (
+      {view === BrowserView.Conversations && (
         <ConversationList
             conversations={conversations}
             projectName={selectedProject}
@@ -51,19 +59,32 @@ export const Browser: React.FC<BrowserProps> = ({ conversations, onExport, onBac
             onSelectionChange={setSelectedUuids}
             onSelectConversation={(conv: Conversation) => {
                 setPreviewConversation(conv);
-                setView('preview');
+                setLastView(BrowserView.Conversations);
+                setView(BrowserView.Preview);
             }}
             onExport={handleExportTrigger}
-            onBack={() => setView('projects')}
+            onBack={() => setView(BrowserView.Projects)}
             onViewStats={onViewStats}
             onChangeSource={onChangeSource}
         />
       )}
 
-      {view === 'preview' && previewConversation && (
+      {view === BrowserView.Search && (
+          <SearchResults
+             conversations={conversations}
+             onSelectConversation={(conv: Conversation) => {
+                 setPreviewConversation(conv);
+                 setLastView(BrowserView.Search);
+                 setView(BrowserView.Preview);
+             }}
+             onBack={() => setView(BrowserView.Projects)}
+          />
+      )}
+
+      {view === BrowserView.Preview && previewConversation && (
           <ConversationPreview
             conversation={previewConversation}
-            onBack={() => setView('conversations')}
+            onBack={() => setView(lastView)}
           />
       )}
     </Box>

--- a/src/ui/components/browser/ConversationPreview.tsx
+++ b/src/ui/components/browser/ConversationPreview.tsx
@@ -1,10 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
+import TextInput from 'ink-text-input';
 import { Conversation } from '../../../providers/types.js';
 
 interface ConversationPreviewProps {
   conversation: Conversation;
   onBack: () => void;
+}
+
+// Helper to escape regex special characters
+function escapeRegExp(string: string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 export const ConversationPreview: React.FC<ConversationPreviewProps> = ({ conversation, onBack }) => {
@@ -14,6 +20,12 @@ export const ConversationPreview: React.FC<ConversationPreviewProps> = ({ conver
     rows: stdout?.rows || 24,
     columns: stdout?.columns || 80
   });
+
+  // Search state
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [matchedLines, setMatchedLines] = useState<number[]>([]);
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(-1);
 
   useEffect(() => {
     if (!stdout) return;
@@ -30,7 +42,7 @@ export const ConversationPreview: React.FC<ConversationPreviewProps> = ({ conver
   const maxWidth = Math.max(20, dims.columns - 6); // Border/Padding safety
 
   // Simple flatten of messages to lines for scrolling with wrapping
-  const lines = React.useMemo(() => {
+  const lines = useMemo(() => {
     const allLines: string[] = [];
     conversation.messages.forEach(msg => {
        const role = msg.sender.toUpperCase();
@@ -51,13 +63,90 @@ export const ConversationPreview: React.FC<ConversationPreviewProps> = ({ conver
     return allLines;
   }, [conversation, maxWidth]);
 
+  // Perform search when query is "submitted" (Enter)
+  const executeSearch = () => {
+      if (!searchQuery) {
+          setMatchedLines([]);
+          setCurrentMatchIndex(-1);
+          setIsSearching(false);
+          return;
+      }
+      const matches: number[] = [];
+      const lowerQuery = searchQuery.toLowerCase();
+
+      lines.forEach((line, idx) => {
+          if (line.toLowerCase().includes(lowerQuery)) {
+              matches.push(idx);
+          }
+      });
+
+      setMatchedLines(matches);
+      if (matches.length > 0) {
+          setCurrentMatchIndex(0);
+          // Jump to first match, centering it if possible
+          const matchLine = matches[0];
+          setScrollOffset(Math.max(0, Math.min(matchLine - Math.floor(viewHeight / 2), lines.length - viewHeight)));
+      } else {
+          setCurrentMatchIndex(-1);
+      }
+      setIsSearching(false);
+  };
+
+  const jumpToMatch = (index: number) => {
+      if (index < 0 || index >= matchedLines.length) return;
+      setCurrentMatchIndex(index);
+      const matchLine = matchedLines[index];
+      // Try to center the match
+      const targetOffset = matchLine - Math.floor(viewHeight / 2);
+      setScrollOffset(Math.max(0, Math.min(targetOffset, lines.length - viewHeight)));
+  };
+
   useInput((input, key) => {
+    if (isSearching) {
+        if (key.return) {
+            executeSearch();
+        }
+        if (key.escape) {
+            setIsSearching(false);
+            setSearchQuery(''); // Clear search on escape
+        }
+        return;
+    }
+
+    // Vim-like navigation
     if (key.upArrow) {
       setScrollOffset(prev => Math.max(0, prev - 1));
     }
     if (key.downArrow) {
       setScrollOffset(prev => Math.min(Math.max(0, lines.length - viewHeight), prev + 1));
     }
+
+    // Page Up/Down could be mapped too, but sticking to basics
+    if (input === 'g') {
+        setScrollOffset(0);
+    }
+    if (input === 'G') {
+        setScrollOffset(Math.max(0, lines.length - viewHeight));
+    }
+
+    if (input === '/') {
+        setIsSearching(true);
+        // Don't clear query immediately so they can edit it
+    }
+
+    if (input === 'n') {
+        if (matchedLines.length > 0) {
+            const next = (currentMatchIndex + 1) % matchedLines.length;
+            jumpToMatch(next);
+        }
+    }
+    if (input === 'N') {
+        if (matchedLines.length > 0) {
+            const prev = (currentMatchIndex - 1 + matchedLines.length) % matchedLines.length;
+            jumpToMatch(prev);
+        }
+    }
+
     if (key.escape || key.backspace || key.delete) {
       onBack();
     }
@@ -65,24 +154,62 @@ export const ConversationPreview: React.FC<ConversationPreviewProps> = ({ conver
 
   const visibleLines = lines.slice(scrollOffset, scrollOffset + viewHeight);
 
+  // Helper to highlight text
+  const renderLine = (text: string, lineIndex: number) => {
+      // Check if this line is the current match
+      const isCurrentMatchLine = matchedLines[currentMatchIndex] === lineIndex;
+
+      if (!searchQuery || matchedLines.indexOf(lineIndex) === -1) {
+           return <Text wrap="truncate-end">{text}</Text>;
+      }
+
+      // Highlight logic with escaped query
+      const escapedQuery = escapeRegExp(searchQuery);
+      const parts = text.split(new RegExp(`(${escapedQuery})`, 'gi'));
+      return (
+          <Text wrap="truncate-end">
+              {parts.map((part, i) => {
+                  const isMatch = part.toLowerCase() === searchQuery.toLowerCase();
+                  if (isMatch) {
+                      return <Text key={i} color="black" backgroundColor={isCurrentMatchLine ? "green" : "yellow"}>{part}</Text>;
+                  }
+                  return <Text key={i}>{part}</Text>;
+              })}
+          </Text>
+      );
+  };
+
   return (
     <Box flexDirection="column" padding={1} width="100%">
-      <Box marginBottom={1} borderStyle="single" borderColor="gray">
+      <Box marginBottom={1} borderStyle="single" borderColor="gray" justifyContent="space-between">
           <Text bold wrap="truncate-end">{conversation.title}</Text>
+          <Text>{matchedLines.length > 0 ? `Match ${currentMatchIndex + 1}/${matchedLines.length}` : ''}</Text>
       </Box>
 
       <Box flexDirection="column" height={viewHeight}>
         {visibleLines.map((line, idx) => (
-          <Text key={idx}>{line}</Text>
+          <Box key={idx}>
+              {renderLine(line, scrollOffset + idx)}
+          </Box>
         ))}
         {lines.length === 0 && <Text italic>No messages to display.</Text>}
       </Box>
 
-      <Box marginTop={1} borderStyle="single" borderColor="gray">
-          <Text>
-              Line {scrollOffset + 1} of {lines.length} | <Text bold>Esc/Backspace</Text> to back
-          </Text>
-      </Box>
+      {isSearching ? (
+          <Box marginTop={1} borderStyle="single" borderColor="cyan">
+              <Text color="cyan">Search: </Text>
+              <TextInput value={searchQuery} onChange={setSearchQuery} focus={isSearching} onSubmit={executeSearch} />
+          </Box>
+      ) : (
+          <Box marginTop={1} borderStyle="single" borderColor="gray">
+              <Text>
+                  <Text bold color="green">Arrows/g/G</Text>: Scroll |
+                  <Text bold color="green"> /</Text>: Search |
+                  <Text bold color="green"> n/N</Text>: Next/Prev Match |
+                  <Text bold color="green"> Esc</Text>: Back
+              </Text>
+          </Box>
+      )}
     </Box>
   );
 };

--- a/src/ui/components/browser/ProjectList.tsx
+++ b/src/ui/components/browser/ProjectList.tsx
@@ -5,12 +5,20 @@ import { Conversation } from '../../../providers/types.js';
 interface ProjectListProps {
   conversations: Conversation[];
   onSelectProject: (projectName: string | null) => void;
+  onSearch: () => void;
   onBack: () => void;
   onViewStats?: () => void;
   onChangeSource?: () => void;
 }
 
-export const ProjectList: React.FC<ProjectListProps> = ({ conversations, onSelectProject, onBack, onViewStats, onChangeSource }) => {
+export const ProjectList: React.FC<ProjectListProps> = ({
+  conversations,
+  onSelectProject,
+  onSearch,
+  onBack,
+  onViewStats,
+  onChangeSource
+}) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   // Extract unique projects
@@ -40,11 +48,14 @@ export const ProjectList: React.FC<ProjectListProps> = ({ conversations, onSelec
     if (key.return) {
       onSelectProject(items[selectedIndex].value);
     }
-    if (key.escape || key.backspace) {
-        onBack();
+    if (input === '/') {
+        onSearch();
     }
     if (input === 's' && onViewStats) {
         onViewStats();
+    }
+    if (key.escape || key.backspace) {
+        onBack();
     }
     if ((input === 'c') && onChangeSource) {
         onChangeSource();
@@ -62,8 +73,10 @@ export const ProjectList: React.FC<ProjectListProps> = ({ conversations, onSelec
           </Text>
         </Box>
       ))}
-      <Box marginTop={1}>
-        <Text color="gray">[Enter] Select  [s] Stats  [c] Change Source  [Esc] Back</Text>
+      <Box marginTop={1} borderStyle="single" borderColor="gray">
+          <Text>
+              <Text bold color="green">Enter</Text>: Select | <Text bold color="green">s</Text>: Stats | <Text bold color="green">/</Text>: Search | <Text bold color="green">c</Text>: Change Source | <Text bold color="green">Esc</Text>: Back
+          </Text>
       </Box>
     </Box>
   );

--- a/src/ui/components/browser/ProjectList.tsx
+++ b/src/ui/components/browser/ProjectList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { Conversation } from '../../../providers/types.js';
 

--- a/src/ui/components/browser/SearchResults.tsx
+++ b/src/ui/components/browser/SearchResults.tsx
@@ -1,0 +1,218 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
+import TextInput from 'ink-text-input';
+import { Conversation } from '../../../providers/types.js';
+
+interface SearchResultsProps {
+  conversations: Conversation[];
+  onSelectConversation: (conversation: Conversation) => void;
+  onBack: () => void;
+}
+
+interface SearchMatch {
+    conversation: Conversation;
+    previewText: string;
+    matchCount: number;
+}
+
+// Helper to escape regex special characters
+function escapeRegExp(string: string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export const SearchResults: React.FC<SearchResultsProps> = ({ conversations, onSelectConversation, onBack }) => {
+  const { stdout } = useStdout();
+  const [query, setQuery] = useState('');
+  const [isSearching, setIsSearching] = useState(true); // Start with focus on search input
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [page, setPage] = useState(0);
+  const [terminalRows, setTerminalRows] = useState(stdout?.rows || 24);
+
+  useEffect(() => {
+    if (!stdout) return;
+    const onResize = () => setTerminalRows(stdout.rows);
+    stdout.on('resize', onResize);
+    return () => {
+      stdout.off('resize', onResize);
+    };
+  }, [stdout]);
+
+  const itemsPerPage = Math.max(5, terminalRows - 13);
+
+  // Perform search
+  const results = useMemo(() => {
+      if (!query || query.length < 2) return [];
+
+      const lowerQuery = query.toLowerCase();
+      const matches: SearchMatch[] = [];
+
+      conversations.forEach(conv => {
+          let count = 0;
+          let firstMatchText = '';
+
+          // Check title
+          if (conv.title.toLowerCase().includes(lowerQuery)) {
+              count++;
+              firstMatchText = `Title: ${conv.title}`;
+          }
+
+          // Check messages
+          conv.messages.forEach(msg => {
+              const idx = msg.text.toLowerCase().indexOf(lowerQuery);
+              if (idx !== -1) {
+                  count++;
+                  if (!firstMatchText) {
+                      // Extract snippet
+                      const start = Math.max(0, idx - 20);
+                      const end = Math.min(msg.text.length, idx + 50);
+                      firstMatchText = `...${msg.text.substring(start, end).replace(/\n/g, ' ')}...`;
+                  }
+              }
+          });
+
+          if (count > 0) {
+              matches.push({
+                  conversation: conv,
+                  previewText: firstMatchText,
+                  matchCount: count
+              });
+          }
+      });
+
+      return matches;
+  }, [conversations, query]);
+
+  const totalPages = Math.ceil(results.length / itemsPerPage);
+
+  useEffect(() => {
+    setPage(0);
+    setSelectedIndex(0);
+  }, [query]);
+
+  const currentItems = useMemo(() => {
+    const start = page * itemsPerPage;
+    return results.slice(start, start + itemsPerPage);
+  }, [results, page, itemsPerPage]);
+
+  useInput((input, key) => {
+    if (isSearching) {
+        if (key.return) {
+            setIsSearching(false); // Stop typing, start navigating
+        }
+        if (key.escape) {
+            onBack();
+        }
+        return;
+    }
+
+    if (key.upArrow) {
+      setSelectedIndex(prev => Math.max(0, prev - 1));
+    }
+    if (key.downArrow) {
+      setSelectedIndex(prev => Math.min(currentItems.length - 1, prev + 1));
+    }
+    if (key.leftArrow) {
+      if (page > 0) {
+        setPage(p => p - 1);
+        setSelectedIndex(0);
+      }
+    }
+    if (key.rightArrow) {
+      if (page < totalPages - 1) {
+        setPage(p => p + 1);
+        setSelectedIndex(0);
+      }
+    }
+    if (key.return) {
+      if (currentItems[selectedIndex]) {
+        onSelectConversation(currentItems[selectedIndex].conversation);
+      }
+    }
+    if (input === '/' || input === 's') {
+        setIsSearching(true);
+    }
+    if (key.escape || key.backspace) {
+        if (query) {
+             // If navigating results, backspace goes back to search input
+             setIsSearching(true);
+        } else {
+             onBack();
+        }
+    }
+  });
+
+  // Render highlighted snippet
+  const renderSnippet = (text: string, isHovered: boolean) => {
+      if (!query) return <Text wrap="truncate-end" color="gray">{text}</Text>;
+
+      const escapedQuery = escapeRegExp(query);
+      const parts = text.split(new RegExp(`(${escapedQuery})`, 'gi'));
+
+      return (
+          <Text wrap="truncate-end">
+              {parts.map((part, i) => {
+                  const isMatch = part.toLowerCase() === query.toLowerCase();
+                  if (isMatch) {
+                      return <Text key={i} color="black" backgroundColor={isHovered ? "green" : "yellow"}>{part}</Text>;
+                  }
+                  return <Text key={i} color="gray">{part}</Text>;
+              })}
+          </Text>
+      );
+  };
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="yellow" padding={1} width="100%">
+        <Box marginBottom={1}>
+            <Text bold color="yellow">Deep Content Search</Text>
+        </Box>
+        <Box marginBottom={1}>
+            <Text>Search: </Text>
+            <TextInput
+                value={query}
+                onChange={setQuery}
+                focus={isSearching}
+                placeholder="Type keywords..."
+            />
+        </Box>
+
+        <Box borderStyle="single" borderColor="gray" marginBottom={0}>
+             <Box width={30}><Text bold>Title</Text></Box>
+             <Box width={40}><Text bold>First Match</Text></Box>
+             <Box width={10}><Text bold>Hits</Text></Box>
+        </Box>
+
+        {currentItems.length > 0 ? currentItems.map((item, idx) => {
+            const isHovered = idx === selectedIndex && !isSearching;
+            return (
+                <Box key={item.conversation.uuid}>
+                    <Text color={isHovered ? 'yellow' : 'white'}>{isHovered ? '> ' : '  '}</Text>
+                    <Box width={30}>
+                        <Text wrap="truncate-end" color={isHovered ? 'yellow' : 'white'}>
+                            {item.conversation.title.substring(0, 28)}
+                        </Text>
+                    </Box>
+                    <Box width={40}>
+                        {renderSnippet(item.previewText, isHovered)}
+                    </Box>
+                    <Box width={10}>
+                         <Text>{item.matchCount}</Text>
+                    </Box>
+                </Box>
+            );
+        }) : (
+            <Box padding={1}>
+                <Text italic color="gray">{query.length > 1 ? 'No results found.' : 'Type to search...'}</Text>
+            </Box>
+        )}
+
+        <Box marginTop={1} borderStyle="single" borderColor="gray">
+             <Text>
+                 <Text bold color="green">Enter</Text>: {isSearching ? 'Navigate Results' : 'Open Conversation'} |
+                 <Text bold color="green"> /</Text>: Edit Search |
+                 <Text bold color="green"> Esc</Text>: Back
+             </Text>
+        </Box>
+    </Box>
+  );
+};

--- a/src/utils/input-resolver.ts
+++ b/src/utils/input-resolver.ts
@@ -88,7 +88,7 @@ export class InputResolver {
             const cleanup = () => {
                 try {
                     zipfile.close();
-                } catch (e) {
+                } catch {
                     // ignore if already closed
                 }
             };
@@ -159,8 +159,8 @@ export class InputResolver {
                         projects = JSON.parse(projectsData.toString('utf8'));
                     }
                     resolve({ conversations, projects });
-                } catch (e) {
-                    reject(e);
+                } catch (error) {
+                    reject(error);
                 }
             });
 
@@ -176,7 +176,7 @@ export class InputResolver {
     const content = await fs.promises.readFile(path, 'utf-8');
     try {
       return JSON.parse(content);
-    } catch (e) {
+    } catch {
       throw new Error(`Failed to parse JSON at ${path}`);
     }
   }


### PR DESCRIPTION
This PR recreates and refreshes the original Search/Vim navigation work from #12 on top of current `main`.

Supersedes #12.

What is included:
- full-text search results view
- Vim-like conversation preview navigation (`/`, `n`, `N`, `g`, `G`)
- CLI optional path auto-load support
- conflict updates to work with the current FileBrowser/session-path architecture already merged into `main`

Validation:
- `pnpm test` passes
- `pnpm build` passes
